### PR TITLE
Ignore style/script elements by default, allow opting for other elements too

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,9 @@ XDocument page = HtmlDocument.Load("page.html")
 Works great when combined with [CSS selectors](https://www.nuget.org/packages/Devlooped.Xml.Css) 
 for XLinq.
 
+Leverages [Microsoft SgmlReader](https://www.nuget.org/packages/Microsoft.Xml.SgmlReader) which 
+converts (almost) all HTML to valid XML.
+
 
 # Dogfooding
 

--- a/src/Html/Html.csproj
+++ b/src/Html/Html.csproj
@@ -8,13 +8,11 @@
     <PackageProjectUrl>https://clarius.org/html</PackageProjectUrl>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <Description>Read HTML as XML using XLinq.</Description>
+    <LangVersion>Preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Xml.SgmlReader" Version="1.8.25" />
     <PackageReference Include="NuGetizer" Version="0.8.0" PrivateAssets="all" />
   </ItemGroup>
@@ -22,5 +20,5 @@
   <ItemGroup>
     <None Include="..\..\readme.md" PackagePath="readme.md" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Html/HtmlReaderSettings.cs
+++ b/src/Html/HtmlReaderSettings.cs
@@ -11,6 +11,18 @@ namespace Devlooped.Html;
 public sealed class HtmlReaderSettings
 {
     /// <summary>
+    /// Default settings when reading HTML, which are:
+    /// <see cref="CaseFolding.ToLower" />, <see cref="IgnoreXmlNamespaces"/>=true  
+    /// and <see cref="SkipElements"/>=["script", "style"].
+    /// </summary>
+    public static HtmlReaderSettings Default { get; } = new HtmlReaderSettings
+    {
+        CaseFolding = CaseFolding.ToLower,
+        IgnoreXmlNamespaces = true,
+        SkipElements = new string[] { "script", "style" },
+    };
+
+    /// <summary>
     /// HTML is case insensitive, so you can choose between converting
     /// to lower case or upper case tags. "None" means that the case is left
     /// alone, except that end tags will be folded to match the start tags.
@@ -21,6 +33,12 @@ public sealed class HtmlReaderSettings
     /// Whether to ignore XML namespaces in the input. Default is true.
     /// </summary>
     public bool IgnoreXmlNamespaces { get; set; } = true;
+
+    /// <summary>
+    /// Elements that should be skipped when reading the HTML so they are 
+    /// not loaded into the resulting XML document. Defaults to no elements.
+    /// </summary>
+    public string[] SkipElements { get; set; } = Array.Empty<string>();
 
     /// <summary>
     /// Specifies how leading and trailing whitespace is handled.

--- a/src/Tests/HtmlTests.cs
+++ b/src/Tests/HtmlTests.cs
@@ -1,3 +1,5 @@
+using System.Xml;
+using System.Xml.Linq;
 using System.Xml.XPath;
 using Devlooped.Html;
 
@@ -6,56 +8,95 @@ namespace Devlooped.Tests;
 public record HtmlTests(ITestOutputHelper Output)
 {
     [Fact]
-    public void IncludesScripts()
+    public void Render()
     {
-        var doc = HtmlDocument.Load(new Uri("file://" + new FileInfo("wikipedia.html").FullName).AbsoluteUri);
+        var doc = HtmlDocument.Load(File("sample.html"));
+
+        Output.WriteLine(doc.ToString());
+    }
+
+    [Fact]
+    public void ExcludesScriptsByDefault()
+    {
+        var doc = HtmlDocument.Load(File("wikipedia.html"));
+
+        Assert.Empty(doc.XPathSelectElements("//script"));
+    }
+
+    [Fact]
+    public void IncludeScriptsExplicitSettings()
+    {
+        var doc = HtmlDocument.Load(File("wikipedia.html"), new HtmlReaderSettings());
 
         Assert.NotEmpty(doc.XPathSelectElements("//script"));
     }
 
     [Fact]
-    public void IncludesStyles()
+    public void ExcludesStylesByDefault()
     {
-        var doc = HtmlDocument.Load(new Uri("file://" + new FileInfo("wikipedia.html").FullName).AbsoluteUri);
+        var doc = HtmlDocument.Load(File("wikipedia.html"));
+
+        Assert.Empty(doc.XPathSelectElements("//style"));
+    }
+
+    [Fact]
+    public void IncludeStylesExplicitSettings()
+    {
+        var doc = HtmlDocument.Load(File("wikipedia.html"), new HtmlReaderSettings());
 
         Assert.NotEmpty(doc.XPathSelectElements("//style"));
     }
 
     [Fact]
-    public void RemovesXmlNamespaces()
+    public void ExcludesXmlNamespacesByDefault()
     {
-        var doc = HtmlDocument.Load(new Uri("file://" + new FileInfo("sample.xhtml").FullName).AbsoluteUri);
+        var doc = HtmlDocument.Load(File("sample.xhtml"));
 
         Assert.NotEmpty(doc.XPathSelectElements("//h1"));
     }
 
     [Fact]
-    public void HtmlSettings()
+    public void IncludeXmlNamespacesExplicitly()
     {
-        var doc = HtmlDocument.Load(new Uri("file://" + new FileInfo("wikipedia.html").FullName).AbsoluteUri,
+        var doc = HtmlDocument.Load(File("sample.xhtml"), new HtmlReaderSettings { IgnoreXmlNamespaces = false });
+        var resolver = new XmlNamespaceManager(new NameTable());
+        resolver.AddNamespace("xh", "http://www.w3.org/1999/xhtml");
+
+        Assert.NotEmpty(doc.XPathSelectElements("//xh:h1", resolver));
+        // Won't match because the elements will have the XHTML namespace
+        Assert.Empty(doc.XPathSelectElements("//h1"));
+    }
+
+    [Fact]
+    public void CanChangeToUpperCaseHtml()
+    {
+        var doc = HtmlDocument.Load(File("wikipedia.html"),
             new HtmlReaderSettings
             {
                 CaseFolding = Sgml.CaseFolding.ToUpper,
-                TextWhitespace = Sgml.TextWhitespaceHandling.TrimBoth,
-                WhitespaceHandling = System.Xml.WhitespaceHandling.None
             });
 
         // The source has lowercase elements
         var central = doc.XPathSelectElement("/HTML/BODY/DIV/H1/SPAN");
 
         Assert.NotNull(central);
-
-        // The source contains leading and trailing whitespaces.
-        Assert.Equal("Wikipedia", central!.Value);
     }
 
     [Fact]
-    public void OptOutOfXmlNamespacesRemoval()
+    public void HtmlSettings()
     {
-        var doc = HtmlDocument.Load(new Uri("file://" + new FileInfo("sample.xhtml").FullName).AbsoluteUri,
-            new HtmlReaderSettings { IgnoreXmlNamespaces = false });
+        var doc = HtmlDocument.Load(File("wikipedia.html"),
+            new HtmlReaderSettings
+            {
+                TextWhitespace = Sgml.TextWhitespaceHandling.TrimBoth,
+                WhitespaceHandling = WhitespaceHandling.None
+            });
 
-        // Won't match because the elements will have the XHTML namespace
-        Assert.Empty(doc.XPathSelectElements("//h1"));
+        var central = doc.XPathSelectElement("/html/body/div/h1/span");
+
+        // The source contains leading and trailing whitespaces.
+        Assert.Equal("Wikipedia", central?.Value);
     }
+
+    string File(string path) => new Uri("file://" + new FileInfo(path).FullName).AbsoluteUri;
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -7,8 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2478" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Xml.SgmlReader" Version="1.8.25" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,10 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="sample.xhtml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="wikipedia.html" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/sample.html
+++ b/src/Tests/sample.html
@@ -1,0 +1,26 @@
+<html lang="en" class="no-js">
+<head>
+    <meta charset="utf-8">
+    <title>Wikipedia</title>
+    <script>
+            // some script
+    </script>
+    <style>
+        /* some style */
+    </style>
+    <meta name="viewport" content="initial-scale=1,user-scalable=yes">
+    <link rel="shortcut icon" href="/static/favicon/wikipedia.ico">
+    <link rel="license" href="//creativecommons.org/licenses/by-sa/3.0/">
+</head>
+<body>
+    <script>
+            // more script
+    </script>
+    <style>
+        /* some style */
+    </style>
+    <h1>
+        Wikipedia
+    </h1>
+</body>
+</html>

--- a/src/Tests/sample.xhtml
+++ b/src/Tests/sample.xhtml
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <body>
     <h1>

--- a/src/Tests/wikipedia.html
+++ b/src/Tests/wikipedia.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html>
 <html lang="en" class="no-js">
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
script/style are typically not part of the content of a page, yet they can be quite large blocks of text that would consume memory unnecessarily.

We should skip both by default, and allow opting in for those as well as potentially other elements via settings.

This commit reworks the way we deal with settings so all overloads have a consistent and non-duplicated behavior.

Defaulting the HTML 4.01 transitional DTD also allows for much cleaner object model, so we opt in for that too.

Fixes #8